### PR TITLE
Change subtitle so I don't accidentally think I'm searching Adam's go…

### DIFF
--- a/workflow_src/info.plist
+++ b/workflow_src/info.plist
@@ -192,9 +192,9 @@ python main.py --action=search --query "{query}"
 				<key>scriptfile</key>
 				<string></string>
 				<key>subtext</key>
-				<string>(Adam's drive search)</string>
+				<string>Add some search terms</string>
 				<key>title</key>
-				<string>Search G-Drive for search terms...</string>
+				<string>Search Google Drive and open...</string>
 				<key>type</key>
 				<integer>0</integer>
 				<key>withspace</key>
@@ -322,9 +322,9 @@ python main.py --action=search --query "{query}"
 				<key>scriptfile</key>
 				<string></string>
 				<key>subtext</key>
-				<string>(Adam's drive search)</string>
+				<string>Add some search terms</string>
 				<key>title</key>
-				<string>Search G-Drive and paste</string>
+				<string>Search Google Drive and Copy to Clipboard</string>
 				<key>type</key>
 				<integer>0</integer>
 				<key>withspace</key>


### PR DESCRIPTION
…ogle drive

A coworker was showing me this, and I was wondering how/why he was searching Adam's Google Drive.

The name of the workflow is already in a few places, so I think it's reasonable to exclude it as a subtext, and include something more useful. I've made it "add some search terms", because you only see it when you don't have any search terms, and as you start typing you see search results